### PR TITLE
Include basic ability to run OCUnit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ xcuserdata/
 /target/
 *~
 #*#
+bin

--- a/modules/xcode-maven-plugin/pom.xml
+++ b/modules/xcode-maven-plugin/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>com.sap.prd.mobile.ios.mios</groupId>
     <artifactId>parent</artifactId>
-    <version>1.7.1-SNAPSHOT</version>
+    <version>1.7.2-SNAPSHOT</version>
     <relativePath>../../parent</relativePath>
   </parent>
   <artifactId>xcode-maven-plugin</artifactId>

--- a/modules/xcode-maven-plugin/pom.xml
+++ b/modules/xcode-maven-plugin/pom.xml
@@ -104,6 +104,11 @@
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-core</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>xcode-plugin</artifactId>
+      <version>1.3.2-SNAPSHOT</version>
+    </dependency>
   </dependencies>
   
   <profiles>

--- a/modules/xcode-maven-plugin/src/main/java/com/sap/prd/mobile/ios/mios/BuildContextAwareMojo.java
+++ b/modules/xcode-maven-plugin/src/main/java/com/sap/prd/mobile/ios/mios/BuildContextAwareMojo.java
@@ -74,11 +74,23 @@ public abstract class BuildContextAwareMojo extends AbstractXCodeMojo
    * @parameter expression="${product.name}"
    */
   private String productName;
+  
+  /**
+   * The name of the project file to be used. The default is the POM artifact-id.
+   * @parameter projectName expression="${xcode.projectName}"
+   * @since 1.7.1
+   */
+  protected String xcodeProjectName;
 
   protected XCodeContext getXCodeContext(final XCodeContext.SourceCodeLocation sourceCodeLocation)
   {
-    final String projectName = project.getArtifactId();
     File projectDirectory = null;
+    String projectName = xcodeProjectName;
+    
+    if (null == projectName) {
+    	projectName = project.getArtifactId();
+    }
+    getLog().info("Setting projectName = <" + projectName + ">");
 
     if(sourceCodeLocation == XCodeContext.SourceCodeLocation.WORKING_COPY) {
       projectDirectory = getXCodeCompileDirectory();

--- a/modules/xcode-maven-plugin/src/main/java/com/sap/prd/mobile/ios/mios/CommandLineBuilder.java
+++ b/modules/xcode-maven-plugin/src/main/java/com/sap/prd/mobile/ios/mios/CommandLineBuilder.java
@@ -55,6 +55,14 @@ class CommandLineBuilder
     return result.toArray(new String[result.size()]);
   }
   
+  String[] createTestCall()
+  {
+	List<String> result = createBaseCall();
+	appendValue(result, "build");
+	appendEnv(result, "TEST_AFTER_BUILD", "YES");
+	return result.toArray(new String[result.size()]);
+  }
+  
   String[] createShowBuildSettingsCall()
   {
     List<String> result = createBaseCall();

--- a/modules/xcode-maven-plugin/src/main/java/com/sap/prd/mobile/ios/mios/XCodeBuildMojo.java
+++ b/modules/xcode-maven-plugin/src/main/java/com/sap/prd/mobile/ios/mios/XCodeBuildMojo.java
@@ -33,24 +33,24 @@ import org.apache.maven.plugin.MojoFailureException;
  */
 public class XCodeBuildMojo extends BuildContextAwareMojo
 {
+  protected XCodeManager xcodeMgr = new XCodeManager(getLog());
   
   @Override
   public void execute() throws MojoExecutionException, MojoFailureException
   {
     
     try {
-      XCodeManager xcodeMgr = new XCodeManager(getLog());
       XCodeContext ctx = getXCodeContext(XCodeContext.SourceCodeLocation.WORKING_COPY);
       getLog().info(ctx.toString());
 
       if (getPackagingType() == PackagingType.FRAMEWORK) {
         // we do not provide a sdk for frameworks as the target should assure that all required sdks are built
-        xcodeMgr.callXcodeBuild(ctx, getPrimaryFmwkConfiguration(), null);
+    	  callXcodeBuild(ctx, getPrimaryFmwkConfiguration(), null);
       }
       else { 
         for (String configuration : getConfigurations()) {
           for (final String sdk : getSDKs()) {
-            xcodeMgr.callXcodeBuild(ctx, configuration, sdk);
+            callXcodeBuild(ctx, configuration, sdk);
           }
         }
       }
@@ -61,5 +61,11 @@ public class XCodeBuildMojo extends BuildContextAwareMojo
     catch (XCodeException ex) {
       throw new MojoExecutionException("XCodeBuild failed due to " + ex.getMessage(), ex);
     }
+  }
+
+  protected void callXcodeBuild(XCodeContext ctx, String configuration,
+			String sdk) throws XCodeException, IOException
+  {
+	  xcodeMgr.callXcodeBuild(ctx, configuration, sdk, false);
   }
 }

--- a/modules/xcode-maven-plugin/src/main/java/com/sap/prd/mobile/ios/mios/XCodeCopySourcesMojo.java
+++ b/modules/xcode-maven-plugin/src/main/java/com/sap/prd/mobile/ios/mios/XCodeCopySourcesMojo.java
@@ -105,6 +105,9 @@ public class XCodeCopySourcesMojo extends AbstractXCodeMojo
         
         if (excludes.accept(sourceFile)) {
           copy(sourceFile, destFile, excludes);
+          if (sourceFile.canExecute()) {
+              destFile.setExecutable(true);
+          }
         }
         else {
           getLog().info("File '" + sourceFile + "' ommited.");

--- a/modules/xcode-maven-plugin/src/main/java/com/sap/prd/mobile/ios/mios/XCodeDefaultConfigurationMojo.java
+++ b/modules/xcode-maven-plugin/src/main/java/com/sap/prd/mobile/ios/mios/XCodeDefaultConfigurationMojo.java
@@ -120,8 +120,10 @@ public class XCodeDefaultConfigurationMojo extends AbstractMojo
             "Property ${" + XCODE_CHECKOUT_DIR + "} found with value '"
                   + projectProperties.getProperty(XCODE_CHECKOUT_DIR) + "'. This value will not be modified.");
 
-      checkoutDirectory = getCanonicalFile(new File(projectProperties.getProperty(XCODE_CHECKOUT_DIR)));
+      checkoutDirectory = getCanonicalFile(new File(new File(project.getBuild().getDirectory()),
+            projectProperties.getProperty(XCODE_CHECKOUT_DIR)));
 
+      projectProperties.setProperty(XCODE_CHECKOUT_DIR, getCanonicalPath(checkoutDirectory));
     }
 
     final File compileDirectory = getCanonicalFile(new File(checkoutDirectory, sourceDirectory));

--- a/modules/xcode-maven-plugin/src/main/java/com/sap/prd/mobile/ios/mios/XCodeManager.java
+++ b/modules/xcode-maven-plugin/src/main/java/com/sap/prd/mobile/ios/mios/XCodeManager.java
@@ -40,20 +40,40 @@ class XCodeManager
    * @throws IOException
    * @throws {@link XCodeException}
    */
-  void callXcodeBuild(XCodeContext ctx, String configuration, final String sdk) throws IOException,
+  void callXcodeBuild(XCodeContext ctx, String configuration, final String sdk, boolean test) throws IOException,
         XCodeException
   {
     final CommandLineBuilder commandLineBuilder = new CommandLineBuilder(configuration, sdk, ctx);
+    final String[] commandLine;
+    if (test) {
+    	commandLine = commandLineBuilder.createTestCall();
+    } else {
+    	commandLine = commandLineBuilder.createBuildCall();
+    }
 
     //
     //TODO The command line printed into the log is not 100% accurate. We have a problem with
     // quotation marks.
-    log.info("Executing xcode command: '" + commandLineBuilder.toString() + "'.");
+    log.info("Executing xcode command: '" + join(" ", commandLine) + "'.");
 
     final int returnValue = Forker.forkProcess(ctx.getOut(), ctx.getProjectRootDirectory(),
-          commandLineBuilder.createBuildCall());
+          commandLine);
     if (returnValue != 0) {
       throw new XCodeException("Could not execute xcodebuild for configuration " + configuration);
     }
+  }
+  
+  private String join(String glue, String[] arg)
+  {
+	boolean first = true;
+	StringBuilder result = new StringBuilder();
+	
+	for (String item : arg) {
+	  if (first) {
+		result.append(glue);
+	  }
+	  result.append(item);
+	}
+	return result.toString();
   }
 }

--- a/modules/xcode-maven-plugin/src/main/java/com/sap/prd/mobile/ios/mios/XCodeTestMojo.java
+++ b/modules/xcode-maven-plugin/src/main/java/com/sap/prd/mobile/ios/mios/XCodeTestMojo.java
@@ -1,0 +1,33 @@
+package com.sap.prd.mobile.ios.mios;
+
+import java.io.IOException;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.OutputStream;
+import java.io.PrintStream;
+
+import au.com.rayh.XcodeBuildOutputParser;
+
+/**
+ * Run the build with tests.
+ * @author John Bito <jwbito@gmail.com>
+ *
+ * @goal xcodetest
+ * @requiresDependencyResolution
+ */
+public class XCodeTestMojo extends XCodeBuildMojo 
+{
+  @Override
+  protected void callXcodeBuild(XCodeContext ctx, String configuration,
+		String sdk) throws XCodeException, IOException {
+	PrintStream origOut = ctx.getOut(),
+			  out = new PrintStream(new XcodeBuildOutputParser(new File("."), origOut).getOutputStream());
+	ctx.setOut(out);
+	try {
+      xcodeMgr.callXcodeBuild(ctx, configuration, sdk, true);
+	} finally {
+		out.close();
+		ctx.setOut(origOut);
+	}
+  }
+}

--- a/modules/xcode-maven-plugin/src/main/java/com/sap/prd/mobile/ios/mios/XCodeTestMojo.java
+++ b/modules/xcode-maven-plugin/src/main/java/com/sap/prd/mobile/ios/mios/XCodeTestMojo.java
@@ -20,8 +20,10 @@ public class XCodeTestMojo extends XCodeBuildMojo
   @Override
   protected void callXcodeBuild(XCodeContext ctx, String configuration,
 		String sdk) throws XCodeException, IOException {
+    File destDir = new File(new File("target"), "surefile-reports"); //TODO Can these values come from Maven?
+    destDir.mkdirs();
 	PrintStream origOut = ctx.getOut(),
-			  out = new PrintStream(new XcodeBuildOutputParser(new File("."), origOut).getOutputStream());
+			  out = new PrintStream(new XcodeBuildOutputParser(destDir, origOut).getOutputStream());
 	ctx.setOut(out);
 	try {
       xcodeMgr.callXcodeBuild(ctx, configuration, sdk, true);

--- a/modules/xcode-maven-plugin/src/main/java/com/sap/prd/mobile/ios/mios/XCodeTestMojo.java
+++ b/modules/xcode-maven-plugin/src/main/java/com/sap/prd/mobile/ios/mios/XCodeTestMojo.java
@@ -26,7 +26,7 @@ public class XCodeTestMojo extends XCodeBuildMojo
 	try {
       xcodeMgr.callXcodeBuild(ctx, configuration, sdk, true);
 	} finally {
-		out.close();
+		out.flush();
 		ctx.setOut(origOut);
 	}
   }

--- a/modules/xcode-maven-plugin/src/main/java/com/sap/prd/mobile/ios/mios/XCodeTestMojo.java
+++ b/modules/xcode-maven-plugin/src/main/java/com/sap/prd/mobile/ios/mios/XCodeTestMojo.java
@@ -12,7 +12,7 @@ import au.com.rayh.XcodeBuildOutputParser;
  * Run the build with tests.
  * @author John Bito <jwbito@gmail.com>
  *
- * @goal xcodetest
+ * @goal test
  * @requiresDependencyResolution
  */
 public class XCodeTestMojo extends XCodeBuildMojo 
@@ -20,7 +20,7 @@ public class XCodeTestMojo extends XCodeBuildMojo
   @Override
   protected void callXcodeBuild(XCodeContext ctx, String configuration,
 		String sdk) throws XCodeException, IOException {
-    File destDir = new File(new File("target"), "surefile-reports"); //TODO Can these values come from Maven?
+    File destDir = new File(new File("target"), "surefire-reports"); //TODO Can these values come from Maven?
     destDir.mkdirs();
 	PrintStream origOut = ctx.getOut(),
 			  out = new PrintStream(new XcodeBuildOutputParser(destDir, origOut).getOutputStream());

--- a/modules/xcode-maven-plugin/src/main/java/com/sap/prd/mobile/ios/mios/XCodeTestMojo.java
+++ b/modules/xcode-maven-plugin/src/main/java/com/sap/prd/mobile/ios/mios/XCodeTestMojo.java
@@ -6,7 +6,7 @@ import java.io.FileOutputStream;
 import java.io.OutputStream;
 import java.io.PrintStream;
 
-import au.com.rayh.XcodeBuildOutputParser;
+import au.com.rayh.XCodeBuildOutputParser;
 
 /**
  * Run the build with tests.

--- a/modules/xcode-maven-plugin/src/main/java/com/sap/prd/mobile/ios/mios/XCodeTestMojo.java
+++ b/modules/xcode-maven-plugin/src/main/java/com/sap/prd/mobile/ios/mios/XCodeTestMojo.java
@@ -23,7 +23,7 @@ public class XCodeTestMojo extends XCodeBuildMojo
     File destDir = new File(new File("target"), "surefire-reports"); //TODO Can these values come from Maven?
     destDir.mkdirs();
 	PrintStream origOut = ctx.getOut(),
-			  out = new PrintStream(new XcodeBuildOutputParser(destDir, origOut).getOutputStream());
+			  out = new PrintStream(new XCodeBuildOutputParser(destDir, origOut).getOutputStream());
 	ctx.setOut(out);
 	try {
       xcodeMgr.callXcodeBuild(ctx, configuration, sdk, true);

--- a/modules/xcode-maven-plugin/src/main/resources/META-INF/plexus/components.xml
+++ b/modules/xcode-maven-plugin/src/main/resources/META-INF/plexus/components.xml
@@ -83,7 +83,7 @@
                 com.sap.prd.mobile.ios.mios:xcode-maven-plugin:xcodebuild
               </compile>
               <test>
-                com.sap.prd.mobile.ios.mios:xcode-maven-plugin:xcodetest
+                com.sap.prd.mobile.ios.mios:xcode-maven-plugin:test
               </test>
               <package>
                 com.sap.prd.mobile.ios.mios:xcode-maven-plugin:attach-version-info,

--- a/modules/xcode-maven-plugin/src/main/resources/META-INF/plexus/components.xml
+++ b/modules/xcode-maven-plugin/src/main/resources/META-INF/plexus/components.xml
@@ -82,6 +82,9 @@
               <compile>
                 com.sap.prd.mobile.ios.mios:xcode-maven-plugin:xcodebuild
               </compile>
+              <test>
+                com.sap.prd.mobile.ios.mios:xcode-maven-plugin:xcodetest
+              </test>
               <package>
                 com.sap.prd.mobile.ios.mios:xcode-maven-plugin:attach-version-info,
                 com.sap.prd.mobile.ios.mios:xcode-maven-plugin:xcode-package,

--- a/modules/xcode-maven-plugin/src/main/resources/com/sap/prd/mobile/ios/mios/zip-subfolder.sh
+++ b/modules/xcode-maven-plugin/src/main/resources/com/sap/prd/mobile/ios/mios/zip-subfolder.sh
@@ -25,18 +25,18 @@ die() {
     exit 1
 }
 
-ROOT_DIR=$1
-SUBFOLDER=$2
-ZIP_FILENAME=$3
-ARCHIVE_FOLDER=$4
+ROOT_DIR="$1"
+SUBFOLDER="$2"
+ZIP_FILENAME="$3"
+ARCHIVE_FOLDER="$4"
 
-echo Zipping the subfolder $SUBFOLDER of the dir $ROOT_DIR into the file $ZIP_FILENAME
+echo Zipping the subfolder "$SUBFOLDER" of the dir "$ROOT_DIR" into the file "$ZIP_FILENAME"
 
-cd $ROOT_DIR || die "Cannot cd into directory $ROOT_DIR containing the application"
+cd "$ROOT_DIR" || die "Cannot cd into directory $ROOT_DIR containing the application"
 
-rm -f $ZIP_FILENAME
+rm -f "$ZIP_FILENAME"
 
-if [ -z $ARCHIVE_FOLDER ]; then
+if [ -z "$ARCHIVE_FOLDER" ]; then
   rm -f "$ZIP_FILENAME"
   zip -y -r "$ZIP_FILENAME" "$SUBFOLDER" || die "Error while creating the zip file"
 else 

--- a/modules/xcode-maven-plugin/src/main/resources/com/sap/prd/mobile/ios/mios/zip-subfolder.sh
+++ b/modules/xcode-maven-plugin/src/main/resources/com/sap/prd/mobile/ios/mios/zip-subfolder.sh
@@ -25,10 +25,10 @@ die() {
     exit 1
 }
 
-ROOT_DIR="$1"
-SUBFOLDER="$2"
-ZIP_FILENAME="$3"
-ARCHIVE_FOLDER="$4"
+ROOT_DIR=$1
+SUBFOLDER=$2
+ZIP_FILENAME=$3
+ARCHIVE_FOLDER=$4
 
 echo Zipping the subfolder "$SUBFOLDER" of the dir "$ROOT_DIR" into the file "$ZIP_FILENAME"
 

--- a/modules/xcode-maven-plugin/src/test/java/com/sap/prd/mobile/ios/mios/CommandLineBuilderTest.java
+++ b/modules/xcode-maven-plugin/src/test/java/com/sap/prd/mobile/ios/mios/CommandLineBuilderTest.java
@@ -49,6 +49,14 @@ public class CommandLineBuilderTest
   }
 
   @Test
+  public void testCommandlineBuilderTestCommand() throws Exception
+  {
+	  CommandLineBuilder commandLineBuilder = new CommandLineBuilder("Release", "mysdk", new XCodeContext("MyLib", Arrays.asList("clean", "build"), projectDirectory, System.out));
+	  assertArrayEquals(new String[] { "xcodebuild", "-project", "MyLib.xcodeproj", "-configuration", "Release", "-sdk",
+			  "mysdk", "DSTROOT=build", "SYMROOT=build", "SHARED_PRECOMPS_DIR=build", "OBJROOT=build", "build", "TEST_AFTER_BUILD=YES" }, commandLineBuilder.createTestCall());
+  }
+  
+  @Test
   public void testCodeSignIdentity() throws Exception
   {
     XCodeContext context = new XCodeContext("MyLib", Arrays.asList("clean", "build"), projectDirectory, System.out, "MyCodeSignIdentity", null, null);

--- a/modules/xcode-maven-plugin/src/test/java/com/sap/prd/mobile/ios/mios/XCodeManagerTest.java
+++ b/modules/xcode-maven-plugin/src/test/java/com/sap/prd/mobile/ios/mios/XCodeManagerTest.java
@@ -82,7 +82,7 @@ public class XCodeManagerTest extends XCodeTest
     // dependency resolution. We build here a project without any
     // predecessor.
 
-    new XCodeManager(log).callXcodeBuild(context, "Release", "iphoneos");
+    new XCodeManager(log).callXcodeBuild(context, "Release", "iphoneos", false);
   }
 
   //
@@ -107,7 +107,7 @@ public class XCodeManagerTest extends XCodeTest
     EasyMock.replay(build, mavenProject);
 
     final XCodeContext context = new XCodeContext("MyLibrary", Arrays.asList("clean", "build"), projectDirectory, System.out);
-    new XCodeManager(log). callXcodeBuild(context, "NON-EXISTNG_CONFIGURATION", "iphoneos");
+    new XCodeManager(log). callXcodeBuild(context, "NON-EXISTNG_CONFIGURATION", "iphoneos", false);
 
   }
 
@@ -136,7 +136,7 @@ public class XCodeManagerTest extends XCodeTest
         setError();
       }
     });
-    new XCodeManager(log).callXcodeBuild(context, "Release", "iphoneos");
+    new XCodeManager(log).callXcodeBuild(context, "Release", "iphoneos", false);
 
   }
 }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.sap.prd.mobile.ios.mios</groupId>
   <artifactId>parent</artifactId>
-  <version>1.7.1-SNAPSHOT</version>
+  <version>1.7.2-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Xcode Maven Plugin Parent</name>
   <description>The parent POM for the xcode-maven-plugin</description>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.sap.prd.mobile.ios.mios</groupId>
   <artifactId>component</artifactId>
-  <version>1.7.1-SNAPSHOT</version>
+  <version>1.7.2-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <properties>


### PR DESCRIPTION
The addition of the XCodeTestMojo and the xcodeProjectName property allows including elements like the following in executions

```
<execution>
    <id>libZMap-testWithReport</id>
    <phase>test</phase>
    <goals>
       <goal>test</goal>
    </goals>
    <configuration>
        <target>libZMapTests</target>
        <xcodeProjectName>libZMap</xcodeProjectName>
        <xcodeCompileDirectory>libs/libZillow/libZMap</xcodeCompileDirectory>
        <buildActions>
            <buildAction>build</buildAction>
        </buildActions>
        <configurations>
             <configuration>Debug</configuration>
        </configurations>
        <sdks>
             <sdk>iphonesimulator</sdk>
        </sdks>
     </configuration>
 </execution>
```

This change relies on a fork of jenkinsci/xcode-plugin https://github.com/jwb/xcode-plugin/tree/output_utility
