### PR TITLE
Remove integration test for resource rule file.

### DIFF
--- a/modules/integration-tests/it-xcode-maven-plugin/src/test/java/com/sap/prd/mobile/ios/mios/StraightForwardLibAndAppTest.java
+++ b/modules/integration-tests/it-xcode-maven-plugin/src/test/java/com/sap/prd/mobile/ios/mios/StraightForwardLibAndAppTest.java
@@ -200,14 +200,6 @@ public class StraightForwardLibAndAppTest extends XCodeTest
   }
 
   @Test
-  public void testResourceRulesExistsInsideIPA() throws Exception
-  {
-    File resourceRulesPlistFile = new File(extractedIpaFolder, "Payload/MyApp.app/ResourceRules.plist");
-    assertTrue("ResourceRules pList file '" + resourceRulesPlistFile + "' does not exist.",
-          resourceRulesPlistFile.isFile());
-  }
-
-  @Test
   public void testAppNameInAppStoreUploadFile() throws Exception
   {
     File[] files = appstoreFolder.listFiles();


### PR DESCRIPTION
ResourceRules has been deprecated in Mavericks and should not be used anymore.