### PR TITLE
Jococo compilation issue with JDK8

### DIFF
--- a/modules/xcode-maven-plugin/pom.xml
+++ b/modules/xcode-maven-plugin/pom.xml
@@ -93,6 +93,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.7.5.201505241946</version>
      </plugin>
 
     </plugins>


### PR DESCRIPTION
Caused by: java.lang.NoSuchFieldException: $jacocoAccess