### PR TITLE
Enable skipping dependency fetching for named configurations

### DIFF
--- a/modules/xcode-maven-plugin/src/main/java/com/sap/prd/mobile/ios/mios/XCodePrepareBuildManager.java
+++ b/modules/xcode-maven-plugin/src/main/java/com/sap/prd/mobile/ios/mios/XCodePrepareBuildManager.java
@@ -23,6 +23,8 @@ import static com.sap.prd.mobile.ios.mios.FileUtils.mkdirs;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -55,8 +57,9 @@ class XCodePrepareBuildManager
   private Map<String, String> additionalPackagingTypes;
 
   private boolean preferFatLibs;
+  private List<String> skipDependenciesForConfigurations = new ArrayList<String>();
 
-  XCodePrepareBuildManager(final ArchiverManager archiverManager,
+    XCodePrepareBuildManager(final ArchiverManager archiverManager,
         final RepositorySystemSession repoSystemSession, final RepositorySystem repoSystem,
         final List<RemoteRepository> projectRepos, final boolean useSymbolicLinks,
         final Map<String, String> additionalPackagingTypes)
@@ -93,6 +96,7 @@ class XCodePrepareBuildManager
       LOGGER.info("No dependencies found.");
     }
 
+    configurations.removeAll(skipDependenciesForConfigurations);
     while (dependentArtifacts.hasNext()) {
 
       final Artifact mainArtifact = (Artifact) dependentArtifacts.next();
@@ -466,4 +470,10 @@ class XCodePrepareBuildManager
           destinationFolder.getCanonicalPath());
   }
 
+    public XCodePrepareBuildManager setSkipDependenciesForConfigurations(String skipDependenciesForConfigurations) {
+        if (skipDependenciesForConfigurations == null)
+            return this;
+        this.skipDependenciesForConfigurations = Arrays.asList(skipDependenciesForConfigurations.split(","));
+        return this;
+    }
 }

--- a/modules/xcode-maven-plugin/src/main/java/com/sap/prd/mobile/ios/mios/XCodePrepareMojo.java
+++ b/modules/xcode-maven-plugin/src/main/java/com/sap/prd/mobile/ios/mios/XCodePrepareMojo.java
@@ -78,14 +78,23 @@ public class XCodePrepareMojo extends AbstractXCodeMojo
   protected List<RemoteRepository> projectRepos;
 
   /**
-   * If set to <code>true</code> the dependency resolution will try to retrieve the fat libs instead
-   * of the sdk specific ones. In all cases the lib resolution will try to fallback to the other
-   * library type if the preferred type is not available.
+   * Comma separated list of the Xcode build configurations that should not require
+   * dependencies to exists.
    * 
-   * @parameter expression="${xcode.preferFatLibs}" default-value="false"
-   * @since 1.5.2
+   * @parameter expression="${xcode.skipDependenciesForConfigurations}" default-value=""
+   * @since 1.14.3
    */
-  protected boolean preferFatLibs;
+  protected String skipDependenciesForConfigurations;
+
+    /**
+     * If set to <code>true</code> the dependency resolution will try to retrieve the fat libs instead
+     * of the sdk specific ones. In all cases the lib resolution will try to fallback to the other
+     * library type if the preferred type is not available.
+     *
+     * @parameter expression="${xcode.preferFatLibs}" default-value="false"
+     * @since 1.5.2
+     */
+    protected boolean preferFatLibs;
 
   /**
    * @parameter expression="${xcode.useSymbolicLinks}" default-value="false"
@@ -104,7 +113,7 @@ public class XCodePrepareMojo extends AbstractXCodeMojo
     try {
       new XCodePrepareBuildManager(archiverManager,
             repoSession, repoSystem, projectRepos, useSymbolicLinks,
-            additionalPackagingTypes).setPreferFalLibs(preferFatLibs)
+            additionalPackagingTypes).setPreferFalLibs(preferFatLibs).setSkipDependenciesForConfigurations(skipDependenciesForConfigurations)
         .prepareBuild(project, getConfigurations(), getSDKs());
     }
     catch (XCodeException ex) {


### PR DESCRIPTION
If you follow instructions to create a separate configs for Beta, Debug, App Store versions (http://www.swwritings.com/post/2013-05-20-concurrent-debug-beta-app-store-builds/) it doesn't make sense to have all dependencies to have the same configuration as well. This property skipDependenciesForConfigurations allows one to skip dependency fetching for named configurations.