### PR TITLE
Building projects using CocoaPods to resolve theirs dependencies   

### DIFF
--- a/modules/xcode-maven-plugin/src/main/java/com/sap/prd/mobile/ios/mios/BuildContextAwareMojo.java
+++ b/modules/xcode-maven-plugin/src/main/java/com/sap/prd/mobile/ios/mios/BuildContextAwareMojo.java
@@ -91,8 +91,10 @@ public abstract class BuildContextAwareMojo extends AbstractXCodeMojo
   protected String target;
 
   /**
-   * Indicates whenever plugin should build workspace instead of project
-
+   * Indicates whenever plugin should build workspace instead of project.
+   * Allows building projects which are using CocoaPods to resolve theirs dependencies.
+   * Please also see <code>installPods</code> property setting to read more about CocaPods integration.
+   *
    * @parameter expression="${xcode.buildWorkspace}"
    */
   protected boolean buildWorkspace;

--- a/modules/xcode-maven-plugin/src/main/java/com/sap/prd/mobile/ios/mios/BuildContextAwareMojo.java
+++ b/modules/xcode-maven-plugin/src/main/java/com/sap/prd/mobile/ios/mios/BuildContextAwareMojo.java
@@ -91,6 +91,13 @@ public abstract class BuildContextAwareMojo extends AbstractXCodeMojo
   protected String target;
 
   /**
+   * Indicates whenever plugin should build workspace instead of project
+
+   * @parameter expression="${xcode.buildWorkspace}"
+   */
+  protected boolean buildWorkspace;
+
+  /**
    * @parameter expression="${product.name}"
    */
   private String productName;
@@ -169,9 +176,13 @@ public abstract class BuildContextAwareMojo extends AbstractXCodeMojo
       _options.put(key.substring(PREFIX_XCODE_OPTIONS.length()), getProperty(key));
     }
 
-    if (null == _options.get("scheme"))
-    managedOptions.put(Options.ManagedOption.PROJECT.getOptionName(), projectName + ".xcodeproj");
+    if (_options.get("scheme") == null) {
+      managedOptions.put(Options.ManagedOption.PROJECT.getOptionName(), projectName + ".xcodeproj");
+    }
 
+    if(buildWorkspace) {
+      managedOptions.put("workspace", projectName + ".xcworkspace");
+    }
 
     return new XCodeContext(getBuildActions(), projectDirectory, System.out, new Settings(_settings, managedSettings),
           new Options(_options, managedOptions));

--- a/modules/xcode-maven-plugin/src/main/java/com/sap/prd/mobile/ios/mios/Options.java
+++ b/modules/xcode-maven-plugin/src/main/java/com/sap/prd/mobile/ios/mios/Options.java
@@ -23,18 +23,24 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-final class Options implements IOptions
-{
+final class Options implements IOptions {
 
-  enum ManagedOption
-  {
-    PROJECT(false, false), CONFIGURATION(false, false), SDK(false, false), TARGET(false, false), SHOWBUILDSETTINGS(
-          "showBuildSettings", false, true),
-    DRY_RUN("dry-run", false, true), SHOWSDKS(false, true), VERSION(false, true), LIST(false, true), USAGE(false, true), HELP(
-          false, true), LICENSE(false, true);
+  enum ManagedOption {
+    PROJECT(false, false),
+    WORKSPACE(false, false),
+    CONFIGURATION(false, false),
+    SDK(false, false),
+    TARGET(false, false),
+    SHOWBUILDSETTINGS("showBuildSettings", false, true),
+    DRY_RUN("dry-run", false, true),
+    SHOWSDKS(false, true),
+    VERSION(false, true),
+    LIST(false, true),
+    USAGE(false, true),
+    HELP(false, true),
+    LICENSE(false, true);
 
-    static ManagedOption forName(String name)
-    {
+    static ManagedOption forName(String name) {
       for (ManagedOption value : values()) {
         if (value.name().equals(name)) {
           return value;
@@ -47,65 +53,62 @@ final class Options implements IOptions
     private final boolean required;
     private final boolean emptyValue;
 
-    ManagedOption(boolean required, boolean emptyValue)
-    {
+    ManagedOption(boolean required, boolean emptyValue) {
       this(null, required, emptyValue);
     }
 
-    ManagedOption(String name, boolean required, boolean emptyValue)
-    {
+    ManagedOption(String name, boolean required, boolean emptyValue) {
       this.name = name;
       this.required = required;
       this.emptyValue = emptyValue;
     }
 
-    boolean isRequired()
-    {
+    boolean isRequired() {
       return required;
     }
 
-    String getOptionName()
-    {
+    String getOptionName() {
       return name == null ? name().toLowerCase() : name;
     }
 
-    boolean hasEmptyValue()
-    {
+    boolean hasEmptyValue() {
       return emptyValue;
     }
   }
 
   private final Map<String, String> userOptions, managedOptions;
 
-  Options(Map<String, String> userOptions, Map<String, String> managedOptions)
-  {
+  Options(Map<String, String> userOptions, Map<String, String> managedOptions) {
 
-    if (userOptions == null)
+    if (userOptions == null) {
       this.userOptions = Collections.emptyMap();
-    else
+    } else {
       this.userOptions = Collections.unmodifiableMap(new HashMap<String, String>(userOptions));
+    }
 
-    if (managedOptions == null)
+    if (managedOptions == null) {
       this.managedOptions = Collections.emptyMap();
-    else
+    } else {
       this.managedOptions = Collections.unmodifiableMap(new HashMap<String, String>(managedOptions));
+    }
 
     validateManagedOptions(this.managedOptions);
 
     validateUserOptions(this.userOptions);
 
-    if(null == this.userOptions.get("scheme") && this.managedOptions.get(ManagedOption.PROJECT.getOptionName() )== null){
-	throw new IllegalOptionException(ManagedOption.PROJECT,"managed option \"project\" or user option \"scheme\" is not available");
+    if (null == this.userOptions.get("scheme") &&
+        this.managedOptions.get(ManagedOption.PROJECT.getOptionName()) == null &&
+        this.managedOptions.get(ManagedOption.WORKSPACE.getOptionName()) == null) {
+
+      throw new IllegalOptionException(ManagedOption.PROJECT,"managed option \"project\" / \"workspace\" or user option \"scheme\" are not available");
     }
   }
 
-  public Map<String, String> getUserOptions()
-  {
+  public Map<String, String> getUserOptions() {
     return userOptions;
   }
 
-  public Map<String, String> getManagedOptions()
-  {
+  public Map<String, String> getManagedOptions() {
     return managedOptions;
   }
 
@@ -113,8 +116,7 @@ final class Options implements IOptions
    * @see com.sap.prd.mobile.ios.mios.IOptions#getAllOptions()
    */
   @Override
-  public Map<String, String> getAllOptions()
-  {
+  public Map<String, String> getAllOptions() {
     final Map<String, String> result = new HashMap<String, String>();
 
     result.putAll(getUserOptions());
@@ -124,71 +126,71 @@ final class Options implements IOptions
   }
 
   /**
-   * @param userOptions
-   *          to be validated.
+   * @param userOptions to be validated.
    * @return the passed in userOptions if validation passed without exception
-   * @throws IllegalArgumentException
-   *           if the userOptions contain a key of an XCode option that is managed by the plugin.
+   * @throws IllegalArgumentException if the userOptions contain a key of an XCode option that is managed by the plugin.
    */
-  private final static Map<String, String> validateUserOptions(Map<String, String> userOptions)
-  {
+  private final static Map<String, String> validateUserOptions(Map<String, String> userOptions) {
 
     for (ManagedOption option : ManagedOption.values()) {
-      if (userOptions.keySet().contains(option.getOptionName()))
+      if (userOptions.keySet().contains(option.getOptionName())) {
         throw new IllegalOptionException(option, "XCode Option '" + option.getOptionName()
-              + "' is managed by the plugin and cannot be modified by the user.");
+            + "' is managed by the plugin and cannot be modified by the user.");
+      }
     }
 
     return userOptions;
   }
 
-  private final static Map<String, String> validateManagedOptions(Map<String, String> managedOptions)
-  {
+  private final static Map<String, String> validateManagedOptions(Map<String, String> managedOptions) {
 
     for (ManagedOption option : ManagedOption.values()) {
 
-      if (option.isRequired() && !managedOptions.containsKey(option.getOptionName()))
+      if (option.isRequired() && !managedOptions.containsKey(option.getOptionName())) {
         throw new IllegalOptionException(option, "Required option '" + option.getOptionName()
-              + "' was not available inside the managed options.");
+            + "' was not available inside the managed options.");
+      }
 
-      if (!managedOptions.containsKey(option.getOptionName()))
+      if (!managedOptions.containsKey(option.getOptionName())) {
         continue;
+      }
 
       final String value = managedOptions.get(option.getOptionName());
 
-      if (!option.hasEmptyValue() && (value == null || value.trim().isEmpty()))
+      if (!option.hasEmptyValue() && (value == null || value.trim().isEmpty())) {
         throw new IllegalOptionException(option, "Invalid option: " + option.getOptionName()
-              + " must be provided with a value.");
-      if (option.hasEmptyValue() && (value != null && value.trim().isEmpty()))
+            + " must be provided with a value.");
+      }
+      if (option.hasEmptyValue() && (value != null && value.trim().isEmpty())) {
         throw new IllegalOptionException(option, "Invalid option: " + option.getOptionName()
-              + " must not be provided with a value.");
+            + " must not be provided with a value.");
+      }
 
     }
 
     for (String key : managedOptions.keySet()) {
-      if (ManagedOption.forName(key.toUpperCase()) == null)
+      if (ManagedOption.forName(key.toUpperCase()) == null) {
         throw new IllegalArgumentException("Option '" + key
-              + "' is not managed by the plugin. This option must not be provided as managed option.");
+            + "' is not managed by the plugin. This option must not be provided as managed option.");
+      }
     }
 
     return managedOptions;
   }
 
   @Override
-  public String toString()
-  {
+  public String toString() {
     final String ls = System.getProperty("line.separator");
     StringBuffer buffer = new StringBuffer();
     for (Map.Entry<String, String> entry : getAllOptions().entrySet()) {
       buffer.append(" -").append(entry.getKey()).append(" ").append(entry.getValue() == null ? "" : entry.getValue())
-        .append(ls);
+          .append(ls);
     }
     return buffer.toString();
   }
 
   @Override
-  public int hashCode()
-  {
+  public int hashCode() {
     final int prime = 31;
     int result = 1;
     result = prime * result + ((managedOptions == null) ? 0 : managedOptions.hashCode());
@@ -197,38 +199,46 @@ final class Options implements IOptions
   }
 
   @Override
-  public boolean equals(Object obj)
-  {
-    if (this == obj) return true;
-    if (obj == null) return false;
-    if (getClass() != obj.getClass()) return false;
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null) {
+      return false;
+    }
+    if (getClass() != obj.getClass()) {
+      return false;
+    }
     Options other = (Options) obj;
     if (managedOptions == null) {
-      if (other.managedOptions != null) return false;
+      if (other.managedOptions != null) {
+        return false;
+      }
+    } else if (!managedOptions.equals(other.managedOptions)) {
+      return false;
     }
-    else if (!managedOptions.equals(other.managedOptions)) return false;
     if (userOptions == null) {
-      if (other.userOptions != null) return false;
+      if (other.userOptions != null) {
+        return false;
+      }
+    } else if (!userOptions.equals(other.userOptions)) {
+      return false;
     }
-    else if (!userOptions.equals(other.userOptions)) return false;
     return true;
   }
 
-  static class IllegalOptionException extends IllegalArgumentException
-  {
+  static class IllegalOptionException extends IllegalArgumentException {
 
     private static final long serialVersionUID = -3298815948503432790L;
 
     private ManagedOption violated;
 
-    IllegalOptionException(ManagedOption vialated, String message)
-    {
+    IllegalOptionException(ManagedOption vialated, String message) {
       super(message);
       this.violated = vialated;
     }
 
-    ManagedOption getViolated()
-    {
+    ManagedOption getViolated() {
       return violated;
     }
   }

--- a/modules/xcode-maven-plugin/src/main/java/com/sap/prd/mobile/ios/mios/Settings.java
+++ b/modules/xcode-maven-plugin/src/main/java/com/sap/prd/mobile/ios/mios/Settings.java
@@ -29,9 +29,9 @@ final class Settings implements ISettings {
   private final static String XCODE_OUTPUT_DIRECTORY = "build";
 
   enum ManagedSetting {
-    DSTROOT(true, XCODE_OUTPUT_DIRECTORY),
 //    SYMROOT(true, XCODE_OUTPUT_DIRECTORY),
     SHARED_PRECOMPS_DIR(true, XCODE_OUTPUT_DIRECTORY),
+    DSTROOT(true, XCODE_OUTPUT_DIRECTORY),
     OBJROOT(true, XCODE_OUTPUT_DIRECTORY),
     CODE_SIGN_IDENTITY(false, null),
     CODE_SIGNING_REQUIRED(false, null),

--- a/modules/xcode-maven-plugin/src/main/java/com/sap/prd/mobile/ios/mios/Settings.java
+++ b/modules/xcode-maven-plugin/src/main/java/com/sap/prd/mobile/ios/mios/Settings.java
@@ -24,22 +24,23 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-final class Settings implements ISettings
-{
+final class Settings implements ISettings {
 
   private final static String XCODE_OUTPUT_DIRECTORY = "build";
 
-  enum ManagedSetting
-  {
-    CODE_SIGN_IDENTITY(false, null), CODE_SIGNING_REQUIRED(false, null), PROVISIONING_PROFILE(false, null), 
-          DSTROOT(true, XCODE_OUTPUT_DIRECTORY), SYMROOT(true, XCODE_OUTPUT_DIRECTORY), SHARED_PRECOMPS_DIR(true, 
-          XCODE_OUTPUT_DIRECTORY), OBJROOT(true, XCODE_OUTPUT_DIRECTORY);
+  enum ManagedSetting {
+    DSTROOT(true, XCODE_OUTPUT_DIRECTORY),
+//    SYMROOT(true, XCODE_OUTPUT_DIRECTORY),
+    SHARED_PRECOMPS_DIR(true, XCODE_OUTPUT_DIRECTORY),
+    OBJROOT(true, XCODE_OUTPUT_DIRECTORY),
+    CODE_SIGN_IDENTITY(false, null),
+    CODE_SIGNING_REQUIRED(false, null),
+    PROVISIONING_PROFILE(false, null);
 
     private final boolean required;
     private String defaultValue;
 
-    static ManagedSetting forName(String name)
-    {
+    static ManagedSetting forName(String name) {
 
       for (ManagedSetting setting : values()) {
         if (setting.name().equals(name)) {
@@ -50,22 +51,19 @@ final class Settings implements ISettings
       return null;
     }
 
-    ManagedSetting(boolean required, String defaultValue)
-    {
+    ManagedSetting(boolean required, String defaultValue) {
       this.required = required;
       this.defaultValue = defaultValue;
     }
 
-    boolean isRequired()
-    {
+    boolean isRequired() {
       return required;
     }
 
-    String getDefaultValue()
-    {
+    String getDefaultValue() {
       return defaultValue;
     }
-  };
+  }
 
   private final static Map<String, String> REQUIRED = new LinkedHashMap<String, String>(7);
 
@@ -80,13 +78,11 @@ final class Settings implements ISettings
 
   private final Map<String, String> userSettings, managedSettings;
 
-  Settings(Map<String, String> userSettings, Map<String, String> managedSettings)
-  {
+  Settings(Map<String, String> userSettings, Map<String, String> managedSettings) {
 
     if (userSettings == null) {
       this.userSettings = Collections.emptyMap();
-    }
-    else {
+    } else {
       this.userSettings = Collections.unmodifiableMap(new HashMap<String, String>(userSettings));
     }
 
@@ -94,28 +90,29 @@ final class Settings implements ISettings
 
     if (managedSettings == null) {
       this.managedSettings = Collections.unmodifiableMap(new HashMap<String, String>(REQUIRED));
-    }
-    else {
+    } else {
 
       Map<String, String> _managedSettings = new HashMap<String, String>();
 
       for (Map.Entry<String, String> e : managedSettings.entrySet()) {
 
-        if (e.getKey() == null || e.getKey().trim().isEmpty())
+        if (e.getKey() == null || e.getKey().trim().isEmpty()) {
           throw new IllegalArgumentException("Empty key found in settings. Value was: '" + e.getValue() + "'.");
+        }
 
-        if (ManagedSetting.forName(e.getKey().trim()) == null)
+        if (ManagedSetting.forName(e.getKey().trim()) == null) {
           throw new IllegalArgumentException("Setting with key '" + e.getKey() + "' and value '" + e.getValue()
-                + "' was provided. This setting is managed by the plugin" +
-                "and must not be provided as managed setting.");
+              + "' was provided. This setting is managed by the plugin" +
+              "and must not be provided as managed setting.");
+        }
 
         if (e.getValue() == null) {
 
           if (e.getKey().equals(ManagedSetting.CODE_SIGN_IDENTITY.name())) {
             throw new IllegalArgumentException("CodesignIdentity was empty: '" + e.getValue()
-                  + "'. If you want to use the code"
-                  + " sign identity defined in the xCode project configuration just do"
-                  + " not provide the 'codeSignIdentity' in your Maven settings.");
+                + "'. If you want to use the code"
+                + " sign identity defined in the xCode project configuration just do"
+                + " not provide the 'codeSignIdentity' in your Maven settings.");
           }
 
           throw new IllegalArgumentException("No value provided for key '" + e.getKey() + "'.");
@@ -131,17 +128,16 @@ final class Settings implements ISettings
   public final Map<String, String> getUserSettings() {
     return Collections.unmodifiableMap(this.userSettings);
   }
-  
+
   public final Map<String, String> getManagedSettings() {
     return Collections.unmodifiableMap(this.managedSettings);
   }
-  
+
   /* (non-Javadoc)
    * @see com.sap.prd.mobile.ios.mios.ISettings#getAllSettings()
    */
   @Override
-  public final Map<String, String> getAllSettings()
-  {
+  public final Map<String, String> getAllSettings() {
     Map<String, String> result = new HashMap<String, String>(this.userSettings.size() + this.managedSettings.size());
     result.putAll(this.userSettings);
     result.putAll(this.managedSettings);
@@ -149,29 +145,26 @@ final class Settings implements ISettings
   }
 
   /**
-   * @param userSettings
-   *          to be validated.
+   * @param userSettings to be validated.
    * @return the passed in userSettings if validation passed without exception
-   * @throws IllegalArgumentException
-   *           if the userSettings contain a key of an XCode setting that is managed by the plugin.
+   * @throws IllegalArgumentException if the userSettings contain a key of an XCode setting that is managed by the
+   *                                  plugin.
    */
-  private final static Map<String, String> validateUserSettings(Map<String, String> userSettings)
-  {
+  private final static Map<String, String> validateUserSettings(Map<String, String> userSettings) {
 
     for (String key : userSettings.keySet()) {
       if (ManagedSetting.forName(key.trim()) != null) {
         throw new IllegalArgumentException(
-              "Setting '"
-                    + key
-                    + "' contained in user settings. This settings is managed by the plugin and must not be provided from outside.");
+            "Setting '"
+                + key
+                + "' contained in user settings. This settings is managed by the plugin and must not be provided from outside.");
       }
     }
     return userSettings;
   }
 
   @Override
-  public String toString()
-  {
+  public String toString() {
     final String ls = System.getProperty("line.separator");
     StringBuffer buffer = new StringBuffer();
     for (Map.Entry<String, String> entry : getAllSettings().entrySet()) {
@@ -181,8 +174,7 @@ final class Settings implements ISettings
   }
 
   @Override
-  public int hashCode()
-  {
+  public int hashCode() {
     final int prime = 31;
     int result = 1;
     result = prime * result + ((managedSettings == null) ? 0 : managedSettings.hashCode());
@@ -191,20 +183,31 @@ final class Settings implements ISettings
   }
 
   @Override
-  public boolean equals(Object obj)
-  {
-    if (this == obj) return true;
-    if (obj == null) return false;
-    if (getClass() != obj.getClass()) return false;
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null) {
+      return false;
+    }
+    if (getClass() != obj.getClass()) {
+      return false;
+    }
     Settings other = (Settings) obj;
     if (managedSettings == null) {
-      if (other.managedSettings != null) return false;
+      if (other.managedSettings != null) {
+        return false;
+      }
+    } else if (!managedSettings.equals(other.managedSettings)) {
+      return false;
     }
-    else if (!managedSettings.equals(other.managedSettings)) return false;
     if (userSettings == null) {
-      if (other.userSettings != null) return false;
+      if (other.userSettings != null) {
+        return false;
+      }
+    } else if (!userSettings.equals(other.userSettings)) {
+      return false;
     }
-    else if (!userSettings.equals(other.userSettings)) return false;
     return true;
   }
 }

--- a/modules/xcode-maven-plugin/src/main/java/com/sap/prd/mobile/ios/mios/XCodeConstants.java
+++ b/modules/xcode-maven-plugin/src/main/java/com/sap/prd/mobile/ios/mios/XCodeConstants.java
@@ -31,7 +31,8 @@ abstract class XCodeConstants
     throw new UnsupportedOperationException("To prevent getting instances");
   }
 
-  final static String XCODE_PROJECT_EXTENTION = ".xcodeproj";
+  final static String XCODE_PROJECT_EXTENSION = ".xcodeproj";
+  final static String XCODE_WORKSPACE_EXTENSION = ".xcworkspace";
   final static String XCODE_CONFIGURATION_FILE_NAME = "project.pbxproj";
 
   @Override

--- a/modules/xcode-maven-plugin/src/main/java/com/sap/prd/mobile/ios/mios/XCodeFatLibraryMojo.java
+++ b/modules/xcode-maven-plugin/src/main/java/com/sap/prd/mobile/ios/mios/XCodeFatLibraryMojo.java
@@ -73,10 +73,10 @@ public class XCodeFatLibraryMojo extends BuildContextAwareMojo
     for (String sdk : getSDKs()) {
       final XCodeContext context = getXCodeContext(XCodeContext.SourceCodeLocation.WORKING_COPY, configuration, sdk);
 
-      final String builtProductsDir = EffectiveBuildSettings.getBuildSetting(context, EffectiveBuildSettings.BUILT_PRODUCTS_DIR);
+      final String builtProductsDir = EffectiveBuildSettings.getBuildSetting(context, "SYMROOT");
       final File buildDir = new File(builtProductsDir);
 
-      final String binaryPath = XCodeBuildLayout.getBinary(buildDir.getParentFile(), configuration, sdk, project.getArtifactId()).getAbsolutePath();
+      final String binaryPath = XCodeBuildLayout.getBinary(buildDir, configuration, sdk, project.getArtifactId()).getAbsolutePath();
       lipoCommand.add(binaryPath);
     }
     final File fatBinaryDestDirectory = new File(new File(project.getBuild().getDirectory()), configuration);

--- a/modules/xcode-maven-plugin/src/main/java/com/sap/prd/mobile/ios/mios/XCodePackageManager.java
+++ b/modules/xcode-maven-plugin/src/main/java/com/sap/prd/mobile/ios/mios/XCodePackageManager.java
@@ -159,9 +159,11 @@ class XCodePackageManager
   void packageHeaders(final XCodeContext xcodeContext, MavenProject project,
         String relativeAlternatePublicHeaderFolderPath) throws IOException, XCodeException
   {
-    final File publicHeaderFolderPath = getPublicHeaderFolderPath(EffectiveBuildSettings.getBuildSetting(xcodeContext, EffectiveBuildSettings.BUILT_PRODUCTS_DIR),
-          EffectiveBuildSettings.getBuildSetting(xcodeContext, EffectiveBuildSettings.PUBLIC_HEADERS_FOLDER_PATH),
-          relativeAlternatePublicHeaderFolderPath);
+    final String builtProductsDir = EffectiveBuildSettings.getBuildSetting(xcodeContext, EffectiveBuildSettings.BUILT_PRODUCTS_DIR);
+    final String publicHeadersDir = EffectiveBuildSettings.getBuildSetting(xcodeContext, EffectiveBuildSettings.PUBLIC_HEADERS_FOLDER_PATH);
+
+    final File publicHeaderFolderPath =
+        getPublicHeaderFolderPath(builtProductsDir, publicHeadersDir, relativeAlternatePublicHeaderFolderPath);
 
     if (!publicHeaderFolderPath.canRead()) {
       LOGGER.warning("Public header folder path '" + publicHeaderFolderPath + "' cannot be read. Unable to package headers.");

--- a/modules/xcode-maven-plugin/src/main/java/com/sap/prd/mobile/ios/mios/XCodePackageManager.java
+++ b/modules/xcode-maven-plugin/src/main/java/com/sap/prd/mobile/ios/mios/XCodePackageManager.java
@@ -159,7 +159,7 @@ class XCodePackageManager
   void packageHeaders(final XCodeContext xcodeContext, MavenProject project,
         String relativeAlternatePublicHeaderFolderPath) throws IOException, XCodeException
   {
-    final String builtProductsDir = EffectiveBuildSettings.getBuildSetting(xcodeContext, EffectiveBuildSettings.BUILT_PRODUCTS_DIR);
+    final String builtProductsDir = EffectiveBuildSettings.getBuildSetting(xcodeContext, "SYMROOT");
     final String publicHeadersDir = EffectiveBuildSettings.getBuildSetting(xcodeContext, EffectiveBuildSettings.PUBLIC_HEADERS_FOLDER_PATH);
 
     final File publicHeaderFolderPath =

--- a/modules/xcode-maven-plugin/src/main/java/com/sap/prd/mobile/ios/mios/XCodePackageMojo.java
+++ b/modules/xcode-maven-plugin/src/main/java/com/sap/prd/mobile/ios/mios/XCodePackageMojo.java
@@ -92,8 +92,12 @@ public class XCodePackageMojo extends BuildContextAwareMojo
 
           new XCodePackageManager(archiverManager, projectHelper).packageHeaders(context, project,
                 relativeAlternatePublicHeaderFolderPath);
-          final File buildDir = XCodeBuildLayout.getBuildDir(projectRootDir);
-          XCodePackageManager.attachLibrary(context, buildDir, project, projectHelper);
+
+          final String builtProductsDir = EffectiveBuildSettings.getBuildSetting(context, EffectiveBuildSettings.BUILT_PRODUCTS_DIR);
+
+
+          final File buildDir = new File(builtProductsDir);
+          XCodePackageManager.attachLibrary(context, buildDir.getParentFile(), project, projectHelper);
         }
       }
 

--- a/modules/xcode-maven-plugin/src/main/java/com/sap/prd/mobile/ios/mios/XCodePackageMojo.java
+++ b/modules/xcode-maven-plugin/src/main/java/com/sap/prd/mobile/ios/mios/XCodePackageMojo.java
@@ -93,11 +93,10 @@ public class XCodePackageMojo extends BuildContextAwareMojo
           new XCodePackageManager(archiverManager, projectHelper).packageHeaders(context, project,
                 relativeAlternatePublicHeaderFolderPath);
 
-          final String builtProductsDir = EffectiveBuildSettings.getBuildSetting(context, EffectiveBuildSettings.BUILT_PRODUCTS_DIR);
-
+          final String builtProductsDir = EffectiveBuildSettings.getBuildSetting(context, "SYMROOT");
 
           final File buildDir = new File(builtProductsDir);
-          XCodePackageManager.attachLibrary(context, buildDir.getParentFile(), project, projectHelper);
+          XCodePackageManager.attachLibrary(context, buildDir, project, projectHelper);
         }
       }
 

--- a/modules/xcode-maven-plugin/src/main/java/com/sap/prd/mobile/ios/mios/XCodePodInstallMojo.java
+++ b/modules/xcode-maven-plugin/src/main/java/com/sap/prd/mobile/ios/mios/XCodePodInstallMojo.java
@@ -1,0 +1,62 @@
+package com.sap.prd.mobile.ios.mios;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.logging.LogManager;
+import java.util.logging.Logger;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+
+/**
+ * Removes existing Pods and performs {@code pod install} execution in project compilation directory.
+ *
+ * @goal pod-install
+ */
+public class XCodePodInstallMojo extends AbstractMojo {
+
+  private static final Logger LOGGER = LogManager.getLogManager().getLogger(XCodePluginLogger.getLoggerName());
+
+  private static final String[] POD_INSTALL = new String[]{ "pod", "install" };
+  private static final String[] RM_POD_FILE_LOCK = new String[]{ "rm", "Podfile.lock" };
+  private static final String[] RM_PODS = new String[]{"rm", "-r", "-f", "./Pods"};
+
+  /**
+   * The xcode directory of the copied sources below the checkout directory.
+   *
+   * @parameter expression="${xcode.compileDirectory}"
+   */
+  private File xcodeCompileDirectory;
+
+  /**
+   * Indicates whenever plugin should perform {@code pod install} before executing {@code xcodebuild}
+
+   * @parameter expression="${xcode.installPods}"
+   */
+  private boolean installPods;
+
+  @Override
+  public void execute() throws MojoExecutionException {
+    if (installPods == false) {
+      return;
+    }
+
+    try {
+      LOGGER.info("Removing `Podfile.lock` ...");
+      Forker.forkProcess(System.out, xcodeCompileDirectory, RM_POD_FILE_LOCK);
+
+      LOGGER.info("Removing `Pods` directory ...");
+      Forker.forkProcess(System.out, xcodeCompileDirectory, RM_PODS);
+
+      LOGGER.info("Executing `pod install` command ... ");
+      final int returnValue = Forker.forkProcess(System.out, xcodeCompileDirectory, POD_INSTALL);
+
+      if (returnValue != 0) {
+        throw new MojoExecutionException("Could not execute `pod install`.");
+      }
+
+    } catch (final IOException e) {
+      throw new MojoExecutionException("Could not execute `pod install`.");
+    }
+  }
+}

--- a/modules/xcode-maven-plugin/src/main/java/com/sap/prd/mobile/ios/mios/XCodePodInstallMojo.java
+++ b/modules/xcode-maven-plugin/src/main/java/com/sap/prd/mobile/ios/mios/XCodePodInstallMojo.java
@@ -9,7 +9,7 @@ import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 
 /**
- * Removes existing Pods and performs {@code pod install} execution in project compilation directory.
+ * Removes existing Pods and performs <code>pod install</code> execution in project compilation directory.
  *
  * @goal pod-install
  */
@@ -29,8 +29,8 @@ public class XCodePodInstallMojo extends AbstractMojo {
   private File xcodeCompileDirectory;
 
   /**
-   * Indicates whenever plugin should perform {@code pod install} before executing {@code xcodebuild}
-
+   * Indicates whenever plugin should perform <code>pod install</code> before executing <code>xcodebuild</code>.
+   *
    * @parameter expression="${xcode.installPods}"
    */
   private boolean installPods;

--- a/modules/xcode-maven-plugin/src/main/java/com/sap/prd/mobile/ios/mios/XCodePrepareBuildManager.java
+++ b/modules/xcode-maven-plugin/src/main/java/com/sap/prd/mobile/ios/mios/XCodePrepareBuildManager.java
@@ -465,5 +465,4 @@ class XCodePrepareBuildManager
           sourceFile.getCanonicalPath(),
           destinationFolder.getCanonicalPath());
   }
-
 }

--- a/modules/xcode-maven-plugin/src/main/java/com/sap/prd/mobile/ios/mios/XCodePrepareMojo.java
+++ b/modules/xcode-maven-plugin/src/main/java/com/sap/prd/mobile/ios/mios/XCodePrepareMojo.java
@@ -102,10 +102,9 @@ public class XCodePrepareMojo extends AbstractXCodeMojo
   {
 
     try {
-      new XCodePrepareBuildManager(archiverManager,
-            repoSession, repoSystem, projectRepos, useSymbolicLinks,
-            additionalPackagingTypes).setPreferFalLibs(preferFatLibs)
-        .prepareBuild(project, getConfigurations(), getSDKs());
+      new XCodePrepareBuildManager(archiverManager, repoSession, repoSystem, projectRepos, useSymbolicLinks, additionalPackagingTypes)
+          .setPreferFalLibs(preferFatLibs)
+          .prepareBuild(project, getConfigurations(), getSDKs());
     }
     catch (XCodeException ex) {
       throw new MojoExecutionException(

--- a/modules/xcode-maven-plugin/src/main/resources/META-INF/plexus/components.xml
+++ b/modules/xcode-maven-plugin/src/main/resources/META-INF/plexus/components.xml
@@ -78,7 +78,8 @@
                 com.sap.prd.mobile.ios.mios:xcode-maven-plugin:prepare-xcode-build
               </initialize>
               <process-sources>
-                com.sap.prd.mobile.ios.mios:xcode-maven-plugin:copy-sources
+                com.sap.prd.mobile.ios.mios:xcode-maven-plugin:copy-sources,
+                com.sap.prd.mobile.ios.mios:xcode-maven-plugin:pod-install
               </process-sources>
               <compile>
                 com.sap.prd.mobile.ios.mios:xcode-maven-plugin:set-default-doxygen-configuration,
@@ -128,10 +129,11 @@
                 com.sap.prd.mobile.ios.mios:xcode-maven-plugin:set-default-configuration,
                 com.sap.prd.mobile.ios.mios:xcode-maven-plugin:skip-library-build,
                 com.sap.prd.mobile.ios.mios:xcode-maven-plugin:xcode-project-validate,
-                com.sap.prd.mobile.ios.mios:xcode-maven-plugin:prepare-xcode-build
+                com.sap.prd.mobile.ios.mios:xcode-maven-plugin:prepare-xcode-build,
               </initialize>
               <process-sources>
-                com.sap.prd.mobile.ios.mios:xcode-maven-plugin:copy-sources
+                com.sap.prd.mobile.ios.mios:xcode-maven-plugin:copy-sources,
+                com.sap.prd.mobile.ios.mios:xcode-maven-plugin:pod-install
               </process-sources>
               <compile>
                 com.sap.prd.mobile.ios.mios:xcode-maven-plugin:xcodebuild
@@ -184,7 +186,8 @@
               <process-sources>
                 com.sap.prd.mobile.ios.mios:xcode-maven-plugin:copy-sources,
                 com.sap.prd.mobile.ios.mios:xcode-maven-plugin:change-versions-in-plist,
-                com.sap.prd.mobile.ios.mios:xcode-maven-plugin:change-app-id
+                com.sap.prd.mobile.ios.mios:xcode-maven-plugin:change-app-id,
+                com.sap.prd.mobile.ios.mios:xcode-maven-plugin:pod-install
               </process-sources>
               <compile>
                 com.sap.prd.mobile.ios.mios:xcode-maven-plugin:xcodebuild

--- a/modules/xcode-maven-plugin/src/site/apt/examples/LibBuildExample.apt.vm
+++ b/modules/xcode-maven-plugin/src/site/apt/examples/LibBuildExample.apt.vm
@@ -55,6 +55,11 @@ Building an iOS Library
               <configuration>Release</configuration>
             </configurations>
           <configuration>
+          <options>
+              <scheme>BaseLibrary</scheme>
+          </options>
+          <buildWorkspace>true</buildWorkspace>
+          <installPods>true</installPods>
         -->
       </plugin>
     </plugins>

--- a/modules/xcode-maven-plugin/src/site/apt/usage.apt.vm
+++ b/modules/xcode-maven-plugin/src/site/apt/usage.apt.vm
@@ -39,11 +39,15 @@ Usage
     * {{{./xcodebuild-mojo.html#codeSignIdentity}codeSignIdentity}}
 
     * {{{./xcodebuild-mojo.html#provisioningProfile}provisioningProfile}}
-    
+
+    * {{{./xcodebuild-mojo.html#buildWorkspace}buildWorkspace}}
+
+    * {{{./pod-install-mojo#installPods}installPods}}
+
     * {{{./change-app-id-mojo.html#appIdSuffix}appIdSuffix}}
  
     * {{{./change-artifact-id-mojo#artifactIdSuffix}artifactIdSuffix}}
- 
+
 
   Example of a <<<pom.xml>>> that provides the above mentioned parameters:
   
@@ -81,9 +85,9 @@ Usage
             <sdk>iphonesimulator</sdk>
             <sdk>iphoneos</sdk>
           </sdks>
-          <defaultAppSdks>iphoneos,iphonesimulator</defaultAppSdks>  <!-- if <sdks> are explicitly provided this property has no effect. 
+          <defaultAppSdks>iphoneos,iphonesimulator</defaultAppSdks>  <!-- If <sdks> are explicitly provided this property has no effect.
                                                                           Can also be set via system property: ${xcode.app.defaultSdks} -->
-          <defaultLibSdks>iphoneos,iphonesimulator</defaultLibSdks>  <!-- if <sdks> are explicitly provided this property has no effect. 
+          <defaultLibSdks>iphoneos,iphonesimulator</defaultLibSdks>  <!-- If <sdks> are explicitly provided this property has no effect.
                                                                           Can also be set via system property: ${xcode.lib.defaultSdks} -->          
           <buildActions>
             <buildAction>clean</buildAction>
@@ -94,6 +98,14 @@ Usage
           <provisioningProfile>42CB38B0-62BB-4242-BD03-72EDB7570842</provisioningProfile> <!-- Can also be set via system property: ${xcode.provisioningProfile} -->
           <appIdSuffix>internal</appIdSuffix>                         <!-- Can also be set via system property: ${xcode.appIdSuffix} -->
           <artifactIdSuffix>release</artifactIdSuffix>                <!-- Can also be set via system property: ${xcode.artifactIdSuffix} -->
+          <options>
+            <scheme>MyLibrary</scheme>                                <!-- Scheme needs to be specified whenever bulding a workspace -->
+          </options>
+          <buildWorkspace>true</buildWorkspace>                       <!-- Indicates whenever `xcodebuild` should receive `-workspace` instaed of `-project`
+                                                                           parameter. Can be used for building projects which are using CocaPods.
+                                                                           Can also be set via system property: ${xcode.buildWorkspace} -->
+          <installPods>true</installPods>                             <!-- If enabled plugin will execute `pod install` before proceeding with build process.
+                                                                           Can also be set via system property: ${xcode.installPods} -->
         </configuration>
       </plugin>
     </plugins>
@@ -200,15 +212,15 @@ Usage
     
     * <<<DSTROOT>>> Is set to"build"
     
-    * <<<SYMROOT>>> Is set to "build"
-    
     * <<<SHARED_PRECOMPS_DIR>>> Is set to "build"
     
     * <<<OBJROOT>>> Is set to "build"
 
   * Managed Options
 
-    * <<<project>>> Is always the maven artifactId
+    * <<<project>>> Is always the maven artifactId. [default]
+
+    * <<<workspace>>> Is always the maven artifactId. Excludes "project" option. [optional]
 
     * <<<configuration>>> Can be provided as dedicated entry in the configuration section of the plugin. See pom.xml example above.
 

--- a/modules/xcode-maven-plugin/src/test/java/com/sap/prd/mobile/ios/mios/CommandLineBuilderTest.java
+++ b/modules/xcode-maven-plugin/src/test/java/com/sap/prd/mobile/ios/mios/CommandLineBuilderTest.java
@@ -73,8 +73,7 @@ public class CommandLineBuilderTest
     XCodeContext context = new XCodeContext(Arrays.asList("clean", "build"), projectDirectory, System.out, null,
           options);
     expect(context, "xcodebuild", "-project", "MyLib.xcodeproj", "-sdk",
-          "mysdk", "-configuration", "Release", "clean", "build", "OBJROOT=build", "SYMROOT=build", "DSTROOT=build",
-          "SHARED_PRECOMPS_DIR=build");
+          "mysdk", "-configuration", "Release", "clean", "build", "OBJROOT=build", "SHARED_PRECOMPS_DIR=build", "DSTROOT=build");
   }
 
   @Test
@@ -95,9 +94,9 @@ public class CommandLineBuilderTest
     XCodeContext context = new XCodeContext(Arrays.asList("clean", "build"), projectDirectory, System.out, settings,
           options);
     expect(context, "xcodebuild", "-project", "MyLib.xcodeproj", "-sdk",
-          "mysdk", "-configuration", "Release", "clean", "build", "OBJROOT=build", "SYMROOT=build", "DSTROOT=build",
+          "mysdk", "-configuration", "Release", "clean", "build",
           "CONFIGURATION_BUILD_DIR=/Users/me/projects/myapp/target/xcode/src/main/xcode/build",
-          "SHARED_PRECOMPS_DIR=build", "VALID_ARCHS=i386");
+          "VALID_ARCHS=i386", "OBJROOT=build", "SHARED_PRECOMPS_DIR=build", "DSTROOT=build");
   }
 
   @Test
@@ -117,8 +116,8 @@ public class CommandLineBuilderTest
     XCodeContext context = new XCodeContext(Arrays.asList("clean", "build"), projectDirectory, System.out, null,
           options);
     expect(context, "xcodebuild", "-project", "MyLib.xcodeproj", "-arch", "i386", "-sdk",
-          "mysdk", "-configuration", "Release", "clean", "build", "OBJROOT=build", "SYMROOT=build", "DSTROOT=build",
-          "SHARED_PRECOMPS_DIR=build");
+          "mysdk", "-configuration", "Release", "clean", "build", "OBJROOT=build", "SHARED_PRECOMPS_DIR=build",
+        "DSTROOT=build");
   }
 
   @Test
@@ -219,8 +218,8 @@ public class CommandLineBuilderTest
     Settings settings = new Settings(userSettings, null);
     XCodeContext context = new XCodeContext(Arrays.asList("clean", "build"), projectDirectory, System.out, settings,
           options);
-    expect(context, "xcodebuild", "-project", "MyLib.xcodeproj", "-arch", "i386", "-target", "MyLib", "-sdk",
-          "iphoneos", "-configuration", "Debug", "clean", "build", "OBJROOT=build", "SYMROOT=build", "DSTROOT=build",
-          "CONFIGURATION_BUILD_DIR=MyLib/build", "SHARED_PRECOMPS_DIR=build", "VALID_ARCHS=i386");
+    expect(context, "xcodebuild", "-project", "MyLib.xcodeproj", "-arch", "i386", "-sdk",
+          "iphoneos", "-configuration", "Debug", "-target", "MyLib", "clean", "build", "CONFIGURATION_BUILD_DIR=MyLib/build",
+          "VALID_ARCHS=i386", "OBJROOT=build", "SHARED_PRECOMPS_DIR=build", "DSTROOT=build");
   }
 }


### PR DESCRIPTION
Hi,

Changes:
- introduced `buildWorkspace` configuration property. Disabled by default. Can be used to build .xcworkspace instead of .xcodeproj
- introduced `installPods` configuration property. Disabled by default. Instructs the plugin to perform `pod install` call on a working copy before proceeding with actual build
- ${SYMROOT} property is not being set by default with 'build' value as it was causing issues with resolving installed pods. If not specified differently, property will be set automatically by the build process

I've tested those changes on `xcode-app` and `xcode-lib`.

I'm open for discussion, improvements and changes :)

Cheers!